### PR TITLE
ci(vcs-conventional-branches): remove debug from printed allowed list

### DIFF
--- a/.github/workflows/vcs-conventional-branches.yml
+++ b/.github/workflows/vcs-conventional-branches.yml
@@ -42,6 +42,5 @@ jobs:
             echo "  - staging                                             "
             echo "  - rollback/<lowercase-name> (letters, numbers, dashes)"
             echo "  - topic/<lowercase-name> (letters, numbers, dashes)   "
-            echo "  - debug/<lowercase-name> (letters, numbers, dashes)   "
             exit 1
           fi


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted branch naming workflow output: removed "debug" from the displayed list of allowed conventions.
  * Validation behavior is unchanged; debug/<name> branches remain valid under the existing rules.
  * Affects only the messaging shown during branch checks in the workflow; no changes to application functionality or release behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->